### PR TITLE
feat: #17 #18 ImagePickerDialog フォルダ選択モード・アドレスバー

### DIFF
--- a/app/widgets/image_picker.py
+++ b/app/widgets/image_picker.py
@@ -11,12 +11,14 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from PyQt6.QtCore import QAbstractListModel, QModelIndex, QSize, Qt
+from PyQt6.QtGui import QKeyEvent
 from PyQt6.QtGui import QColor, QPainter, QPixmap
 from PyQt6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QListView,
     QPushButton,
     QSizePolicy,
@@ -186,12 +188,11 @@ class ImagePickerDialog(QDialog):
         self._btn_up = QPushButton("↑ 上へ")
         self._btn_up.setFixedWidth(80)
         self._btn_up.clicked.connect(self._on_go_up)
-        self._path_label = QLabel()
-        self._path_label.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
-        )
+        self._address_bar = QLineEdit()
+        self._address_bar.setPlaceholderText("パスを入力して Enter")
+        self._address_bar.returnPressed.connect(self._on_address_entered)
         nav.addWidget(self._btn_up)
-        nav.addWidget(self._path_label)
+        nav.addWidget(self._address_bar)
         layout.addLayout(nav)
 
         # グリッドビュー
@@ -219,12 +220,16 @@ class ImagePickerDialog(QDialog):
             QDialogButtonBox.StandardButton.Ok
             | QDialogButtonBox.StandardButton.Cancel
         )
-        self._buttons.button(QDialogButtonBox.StandardButton.Ok).setText("決定")
-        self._buttons.button(QDialogButtonBox.StandardButton.Cancel).setText("キャンセル")
+        ok_btn = self._buttons.button(QDialogButtonBox.StandardButton.Ok)
+        cancel_btn = self._buttons.button(QDialogButtonBox.StandardButton.Cancel)
+        ok_btn.setText("決定")
+        cancel_btn.setText("キャンセル")
+        # アドレスバーの Enter がダイアログ OK に伝播しないよう autoDefault を無効化
+        ok_btn.setAutoDefault(False)
+        ok_btn.setDefault(False)
+        cancel_btn.setAutoDefault(False)
         # フォルダモードは OK を常に有効（未選択時は現在ディレクトリを返す）
-        self._buttons.button(QDialogButtonBox.StandardButton.Ok).setEnabled(
-            self._mode == "folder"
-        )
+        ok_btn.setEnabled(self._mode == "folder")
         self._buttons.accepted.connect(self.accept)
         self._buttons.rejected.connect(self.reject)
         layout.addWidget(self._buttons)
@@ -244,7 +249,8 @@ class ImagePickerDialog(QDialog):
 
     def _navigate(self, directory: Path) -> None:
         self._current_dir = directory
-        self._path_label.setText(str(directory))
+        self._address_bar.setText(str(directory))
+        self._address_bar.setStyleSheet("")
         self._btn_up.setEnabled(directory.parent != directory)
 
         items: list[_PickerItem] = []
@@ -280,6 +286,13 @@ class ImagePickerDialog(QDialog):
     def _on_go_up(self) -> None:
         self._navigate(self._current_dir.parent)
 
+    def _on_address_entered(self) -> None:
+        p = Path(self._address_bar.text().strip())
+        if p.is_dir():
+            self._navigate(p)
+        else:
+            self._address_bar.setStyleSheet("QLineEdit { border: 1px solid red; }")
+
     def _on_item_clicked(self, index: QModelIndex) -> None:
         item: _PickerItem = index.data(Qt.ItemDataRole.UserRole)
         if not item:
@@ -301,6 +314,14 @@ class ImagePickerDialog(QDialog):
         else:
             self._selected_path = item.path
             self.accept()
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        # アドレスバー入力中の Enter/Return を QDialog::keyPressEvent に伝播させない
+        if (event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter)
+                and self._address_bar.hasFocus()):
+            event.accept()
+            return
+        super().keyPressEvent(event)
 
     # ------------------------------------------------------------------
     # 結果取得

--- a/app/widgets/image_picker.py
+++ b/app/widgets/image_picker.py
@@ -157,11 +157,16 @@ class _PickerDelegate(QStyledItemDelegate):
 
 
 class ImagePickerDialog(QDialog):
-    """フォルダ内の画像をサムネイル付きグリッドで表示して選択するダイアログ。"""
+    """フォルダ内の画像・フォルダをグリッドで表示して選択するダイアログ。
 
-    def __init__(self, start_path: str = "", parent=None):
+    mode="image"（デフォルト）: 画像ファイルを選択して返す
+    mode="folder": フォルダのみ表示し、フォルダパスを返す
+    """
+
+    def __init__(self, start_path: str = "", mode: str = "image", parent=None):
         super().__init__(parent)
-        self.setWindowTitle("サムネイル画像を選択")
+        self._mode = mode
+        self.setWindowTitle("フォルダを選択" if mode == "folder" else "サムネイル画像を選択")
         self.setMinimumSize(640, 520)
         self._selected_path: str | None = None
         self._current_dir: Path = self._resolve_start(start_path)
@@ -216,7 +221,10 @@ class ImagePickerDialog(QDialog):
         )
         self._buttons.button(QDialogButtonBox.StandardButton.Ok).setText("決定")
         self._buttons.button(QDialogButtonBox.StandardButton.Cancel).setText("キャンセル")
-        self._buttons.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
+        # フォルダモードは OK を常に有効（未選択時は現在ディレクトリを返す）
+        self._buttons.button(QDialogButtonBox.StandardButton.Ok).setEnabled(
+            self._mode == "folder"
+        )
         self._buttons.accepted.connect(self.accept)
         self._buttons.rejected.connect(self.reject)
         layout.addWidget(self._buttons)
@@ -253,11 +261,17 @@ class ImagePickerDialog(QDialog):
                 continue
             if entry.is_dir():
                 items.append(_PickerItem(str(entry), entry.name, is_folder=True))
-            elif entry.suffix.lower() in IMAGE_EXTENSIONS:
+            elif self._mode == "image" and entry.suffix.lower() in IMAGE_EXTENSIONS:
                 items.append(_PickerItem(str(entry), entry.name, is_folder=False))
 
         self._model.set_items(items)
         self._view.clearSelection()
+
+        # フォルダモードでは現在ディレクトリを選択状態にする
+        if self._mode == "folder":
+            self._selected_path = str(directory)
+            name = directory.name or str(directory)
+            self._selection_label.setText(f"選択中: {name}")
 
     # ------------------------------------------------------------------
     # スロット
@@ -268,7 +282,12 @@ class ImagePickerDialog(QDialog):
 
     def _on_item_clicked(self, index: QModelIndex) -> None:
         item: _PickerItem = index.data(Qt.ItemDataRole.UserRole)
-        if item and not item.is_folder:
+        if not item:
+            return
+        if self._mode == "folder" and item.is_folder:
+            self._selected_path = item.path
+            self._selection_label.setText(f"選択中: {item.name}")
+        elif self._mode == "image" and not item.is_folder:
             self._selected_path = item.path
             self._selection_label.setText(f"選択中: {item.name}")
             self._buttons.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)

--- a/app/widgets/image_picker.py
+++ b/app/widgets/image_picker.py
@@ -10,9 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from PyQt6.QtCore import QAbstractListModel, QModelIndex, QSize, Qt
-from PyQt6.QtGui import QKeyEvent
-from PyQt6.QtGui import QColor, QPainter, QPixmap
+from PyQt6.QtCore import QAbstractListModel, QModelIndex, QSize, Qt, QTimer
+from PyQt6.QtGui import QColor, QKeyEvent, QPainter, QPixmap
 from PyQt6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -31,6 +30,9 @@ from PyQt6.QtWidgets import (
 from app.widgets.thumbnail_loader import shared_loader
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
+
+# アドレスバーのデバウンス待機時間（ms）
+_ADDRESS_DEBOUNCE_MS = 300
 
 # サムネイル表示サイズ（正方形）とロードサイズ
 _THUMB_PX = 120
@@ -165,9 +167,12 @@ class ImagePickerDialog(QDialog):
     mode="folder": フォルダのみ表示し、フォルダパスを返す
     """
 
-    def __init__(self, start_path: str = "", mode: str = "image", parent=None):
+    def __init__(self, start_path: str = "", mode: str = "image",
+                 address_debounce_ms: int = _ADDRESS_DEBOUNCE_MS, parent=None):
         super().__init__(parent)
         self._mode = mode
+        self._debounce_ms = address_debounce_ms
+        self._address_valid = True
         self.setWindowTitle("フォルダを選択" if mode == "folder" else "サムネイル画像を選択")
         self.setMinimumSize(640, 520)
         self._selected_path: str | None = None
@@ -190,7 +195,13 @@ class ImagePickerDialog(QDialog):
         self._btn_up.clicked.connect(self._on_go_up)
         self._address_bar = QLineEdit()
         self._address_bar.setPlaceholderText("パスを入力して Enter")
-        self._address_bar.returnPressed.connect(self._on_address_entered)
+        self._debounce_timer = QTimer(self)
+        self._debounce_timer.setSingleShot(True)
+        self._debounce_timer.timeout.connect(self._on_address_validate)
+        self._address_bar.textChanged.connect(
+            lambda: self._debounce_timer.start(self._debounce_ms)
+        )
+        self._address_bar.returnPressed.connect(self._on_address_committed)
         nav.addWidget(self._btn_up)
         nav.addWidget(self._address_bar)
         layout.addLayout(nav)
@@ -228,6 +239,7 @@ class ImagePickerDialog(QDialog):
         ok_btn.setAutoDefault(False)
         ok_btn.setDefault(False)
         cancel_btn.setAutoDefault(False)
+        self._ok_btn = ok_btn
         # フォルダモードは OK を常に有効（未選択時は現在ディレクトリを返す）
         ok_btn.setEnabled(self._mode == "folder")
         self._buttons.accepted.connect(self.accept)
@@ -249,7 +261,10 @@ class ImagePickerDialog(QDialog):
 
     def _navigate(self, directory: Path) -> None:
         self._current_dir = directory
+        self._debounce_timer.stop()
+        self._address_bar.blockSignals(True)
         self._address_bar.setText(str(directory))
+        self._address_bar.blockSignals(False)
         self._address_bar.setStyleSheet("")
         self._btn_up.setEnabled(directory.parent != directory)
 
@@ -286,12 +301,32 @@ class ImagePickerDialog(QDialog):
     def _on_go_up(self) -> None:
         self._navigate(self._current_dir.parent)
 
-    def _on_address_entered(self) -> None:
+    def _on_address_validate(self) -> None:
+        """デバウンス後にバリデートのみ実施（ナビゲートしない）。"""
+        p = Path(self._address_bar.text().strip())
+        self._address_valid = p.is_dir()
+        self._address_bar.setStyleSheet(
+            "" if self._address_valid else "QLineEdit { border: 1px solid red; }"
+        )
+        self._update_ok_btn()
+
+    def _on_address_committed(self) -> None:
+        """Enter 押下時：タイマーをキャンセルしてナビゲートを試みる。"""
+        self._debounce_timer.stop()
         p = Path(self._address_bar.text().strip())
         if p.is_dir():
             self._navigate(p)
         else:
+            self._address_valid = False
             self._address_bar.setStyleSheet("QLineEdit { border: 1px solid red; }")
+            self._update_ok_btn()
+
+    def _update_ok_btn(self) -> None:
+        if self._mode == "folder":
+            self._ok_btn.setEnabled(self._address_valid)
+        else:
+            has_selection = bool(self._selected_path)
+            self._ok_btn.setEnabled(self._address_valid and has_selection)
 
     def _on_item_clicked(self, index: QModelIndex) -> None:
         item: _PickerItem = index.data(Qt.ItemDataRole.UserRole)
@@ -303,7 +338,7 @@ class ImagePickerDialog(QDialog):
         elif self._mode == "image" and not item.is_folder:
             self._selected_path = item.path
             self._selection_label.setText(f"選択中: {item.name}")
-            self._buttons.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
+            self._update_ok_btn()
 
     def _on_item_double_clicked(self, index: QModelIndex) -> None:
         item: _PickerItem = index.data(Qt.ItemDataRole.UserRole)

--- a/app/widgets/image_picker.py
+++ b/app/widgets/image_picker.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from PyQt6.QtCore import QAbstractListModel, QModelIndex, QSize, Qt, QTimer
+from PyQt6.QtCore import QAbstractListModel, QModelIndex, QSize, QStandardPaths, Qt, QTimer
 from PyQt6.QtGui import QColor, QKeyEvent, QPainter, QPixmap
 from PyQt6.QtWidgets import (
     QDialog,
@@ -33,6 +33,14 @@ IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
 
 # アドレスバーのデバウンス待機時間（ms）
 _ADDRESS_DEBOUNCE_MS = 300
+
+# クイックアクセスボタン（ラベル, StandardLocation）
+_QUICK_PLACES: list[tuple[str, QStandardPaths.StandardLocation]] = [
+    ("ホーム",         QStandardPaths.StandardLocation.HomeLocation),
+    ("デスクトップ",   QStandardPaths.StandardLocation.DesktopLocation),
+    ("ダウンロード",   QStandardPaths.StandardLocation.DownloadLocation),
+    ("ピクチャ",       QStandardPaths.StandardLocation.PicturesLocation),
+]
 
 # サムネイル表示サイズ（正方形）とロードサイズ
 _THUMB_PX = 120
@@ -205,6 +213,20 @@ class ImagePickerDialog(QDialog):
         nav.addWidget(self._btn_up)
         nav.addWidget(self._address_bar)
         layout.addLayout(nav)
+
+        # クイックアクセスボタン
+        quick = QHBoxLayout()
+        for label, loc in _QUICK_PLACES:
+            path_str = QStandardPaths.writableLocation(loc)
+            p = Path(path_str) if path_str else None
+            btn = QPushButton(label)
+            if p and p.is_dir():
+                btn.clicked.connect(lambda checked, d=p: self._navigate(d))
+            else:
+                btn.hide()
+            quick.addWidget(btn)
+        quick.addStretch()
+        layout.addLayout(quick)
 
         # グリッドビュー
         self._model = _PickerModel(self)

--- a/app/windows/card_dialog.py
+++ b/app/windows/card_dialog.py
@@ -41,6 +41,7 @@ class CardDialog(QDialog):
         # フォルダパス
         folder_row = QHBoxLayout()
         self._folder_edit = QLineEdit()
+        self._folder_edit.textChanged.connect(self._on_folder_text_changed)
         btn_folder = QPushButton("参照...")
         btn_folder.clicked.connect(self._on_browse_folder)
         folder_row.addWidget(self._folder_edit)
@@ -51,6 +52,7 @@ class CardDialog(QDialog):
         thumb_row = QHBoxLayout()
         self._thumb_edit = QLineEdit()
         self._thumb_edit.setPlaceholderText("（未設定）")
+        self._thumb_edit.textChanged.connect(self._on_thumb_text_changed)
         btn_thumb = QPushButton("選択...")
         btn_thumb.clicked.connect(self._on_browse_thumbnail)
         thumb_row.addWidget(self._thumb_edit)
@@ -67,6 +69,7 @@ class CardDialog(QDialog):
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
+        self._ok_btn = buttons.button(QDialogButtonBox.StandardButton.Ok)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
@@ -76,6 +79,27 @@ class CardDialog(QDialog):
         self._folder_edit.setText(card.folder_path)
         self._thumb_edit.setText(card.thumbnail or "")
         self._recursive_check.setChecked(card.recursive)
+        self._update_ok_state()
+
+    def _on_folder_text_changed(self, text: str) -> None:
+        from pathlib import Path
+        invalid = bool(text and not Path(text).is_dir())
+        self._folder_edit.setStyleSheet("QLineEdit { border: 1px solid red; }" if invalid else "")
+        self._update_ok_state()
+
+    def _on_thumb_text_changed(self, text: str) -> None:
+        from pathlib import Path
+        invalid = bool(text and not Path(text).is_file())
+        self._thumb_edit.setStyleSheet("QLineEdit { border: 1px solid red; }" if invalid else "")
+        self._update_ok_state()
+
+    def _update_ok_state(self) -> None:
+        from pathlib import Path
+        folder = self._folder_edit.text()
+        thumb = self._thumb_edit.text()
+        folder_ok = bool(folder) and Path(folder).is_dir()
+        thumb_ok = not thumb or Path(thumb).is_file()
+        self._ok_btn.setEnabled(folder_ok and thumb_ok)
 
     def _on_browse_folder(self) -> None:
         from app.widgets.image_picker import ImagePickerDialog

--- a/app/windows/card_dialog.py
+++ b/app/windows/card_dialog.py
@@ -8,7 +8,6 @@ from PyQt6.QtWidgets import (
     QCheckBox,
     QDialog,
     QDialogButtonBox,
-    QFileDialog,
     QFormLayout,
     QHBoxLayout,
     QLabel,
@@ -79,12 +78,17 @@ class CardDialog(QDialog):
         self._recursive_check.setChecked(card.recursive)
 
     def _on_browse_folder(self) -> None:
-        path = QFileDialog.getExistingDirectory(self, "フォルダを選択")
-        if path:
-            self._folder_edit.setText(path)
-            if not self._title_edit.text():
-                import os
-                self._title_edit.setText(os.path.basename(path))
+        from app.widgets.image_picker import ImagePickerDialog
+
+        start = self._folder_edit.text() or ""
+        dlg = ImagePickerDialog(start_path=start, mode="folder", parent=self)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            path = dlg.selected_path()
+            if path:
+                self._folder_edit.setText(path)
+                if not self._title_edit.text():
+                    import os
+                    self._title_edit.setText(os.path.basename(path))
 
     def _on_browse_thumbnail(self) -> None:
         from app.widgets.image_picker import ImagePickerDialog


### PR DESCRIPTION
## Summary

- **#17** `ImagePickerDialog` にフォルダ選択モード (`mode="folder"`) を追加
  - フォルダのみ表示、シングルクリックでフォルダ選択、ダブルクリックで移動
  - OK ボタンは最初から有効（未選択時は現在ディレクトリを返す）
  - `CardDialog._on_browse_folder` を `QFileDialog.getExistingDirectory` から `ImagePickerDialog(mode="folder")` に変更
- **#18** アドレスバー（`QLineEdit`）を追加
  - 入力中（デバウンス 300ms 後）はバリデートのみ（赤枠）、ナビゲートしない
  - Enter のみナビゲートを実行（trailing slash 問題を回避）
  - 無効パス中は OK ボタンを無効化
- `CardDialog` のフォルダパス・サムネイルパス入力欄にリアルタイムバリデーション追加（無効時は赤枠 + OK 無効化）
- **#19** クイックアクセスボタン（ホーム・デスクトップ・ダウンロード・ピクチャ）を追加
  - ナビバーとグリッドの間に水平ボタン行を配置
  - `QStandardPaths` でOS依存パスをクロスプラットフォームに解決
  - ディレクトリが存在しない場合はボタンを非表示

Closes #17
Closes #18
Closes #19

## Test plan

- [ ] CardDialog「参照...」ボタンでフォルダ選択ダイアログが開く
- [ ] フォルダモードで画像ファイルが非表示になっている
- [ ] ダブルクリックでフォルダを移動できる、シングルクリックで選択できる
- [ ] アドレスバーに有効なパスを入力して Enter でナビゲートできる
- [ ] アドレスバーに `/path/to/dir/` (trailing slash) を入力しても入力が妨げられない
- [ ] 無効なパス入力中は赤枠が表示され OK ボタンが無効化される
- [ ] CardDialog のフォルダ・サムネイル欄で無効パス入力時に赤枠 + OK 無効化
- [ ] ホーム・デスクトップ・ダウンロード・ピクチャボタンが表示され、クリックで移動できる
- [ ] 存在しないディレクトリのボタンは非表示になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)