### PR TITLE
feat: #20 #21 #22 ImagePickerDialog ソート・隠しファイル・ビュー切替

### DIFF
--- a/app/widgets/card_grid.py
+++ b/app/widgets/card_grid.py
@@ -219,19 +219,15 @@ class CardDelegate(QStyledItemDelegate):
 
         pixmap = self._pixmaps.get(card.thumbnail) if card.thumbnail else None
         if pixmap:
+            painter.fillRect(thumb_rect, QColor(0, 0, 0))
             scaled = pixmap.scaled(
                 thumb_rect.size(),
-                Qt.AspectRatioMode.KeepAspectRatioByExpanding,
+                Qt.AspectRatioMode.KeepAspectRatio,
                 Qt.TransformationMode.SmoothTransformation,
             )
-            # センタークリップ
-            x_off = (scaled.width() - thumb_rect.width()) // 2
-            y_off = (scaled.height() - thumb_rect.height()) // 2
-            painter.drawPixmap(
-                thumb_rect,
-                scaled,
-                scaled.rect().adjusted(x_off, y_off, -x_off, -y_off),
-            )
+            x_off = (thumb_rect.width() - scaled.width()) // 2
+            y_off = (thumb_rect.height() - scaled.height()) // 2
+            painter.drawPixmap(thumb_rect.x() + x_off, thumb_rect.y() + y_off, scaled)
         else:
             # サムネイルなし
             painter.fillRect(thumb_rect, QColor(colors["thumb_bg"]))

--- a/app/widgets/image_picker.py
+++ b/app/widgets/image_picker.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from PyQt6.QtCore import QAbstractListModel, QModelIndex, QSize, QStandardPaths, Qt, QTimer
 from PyQt6.QtGui import QColor, QKeyEvent, QPainter, QPixmap
 from PyQt6.QtWidgets import (
+    QComboBox,
     QDialog,
     QDialogButtonBox,
     QHBoxLayout,
@@ -33,6 +34,13 @@ IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
 
 # アドレスバーのデバウンス待機時間（ms）
 _ADDRESS_DEBOUNCE_MS = 300
+
+# ソートオプション（表示ラベル, 内部キー）
+_SORT_OPTIONS: list[tuple[str, str]] = [
+    ("名前",     "name"),
+    ("更新日時", "mtime"),
+    ("サイズ",   "size"),
+]
 
 # クイックアクセスボタン（ラベル, StandardLocation）
 _QUICK_PLACES: list[tuple[str, QStandardPaths.StandardLocation]] = [
@@ -56,6 +64,8 @@ class _PickerItem:
     path: str
     name: str
     is_folder: bool
+    mtime: float = 0.0
+    size: int = 0
 
 
 class _PickerModel(QAbstractListModel):
@@ -181,6 +191,8 @@ class ImagePickerDialog(QDialog):
         self._mode = mode
         self._debounce_ms = address_debounce_ms
         self._address_valid = True
+        self._sort_key: str = "name"
+        self._sort_ascending: bool = True
         self.setWindowTitle("フォルダを選択" if mode == "folder" else "サムネイル画像を選択")
         self.setMinimumSize(640, 520)
         self._selected_path: str | None = None
@@ -226,6 +238,17 @@ class ImagePickerDialog(QDialog):
                 btn.hide()
             quick.addWidget(btn)
         quick.addStretch()
+        self._sort_combo = QComboBox()
+        for label, key in _SORT_OPTIONS:
+            self._sort_combo.addItem(label, userData=key)
+        self._sort_combo.currentIndexChanged.connect(self._on_sort_changed)
+        quick.addWidget(self._sort_combo)
+        self._sort_dir_btn = QPushButton("↑")
+        self._sort_dir_btn.setCheckable(True)
+        self._sort_dir_btn.setChecked(True)
+        self._sort_dir_btn.setFixedWidth(32)
+        self._sort_dir_btn.toggled.connect(self._on_sort_dir_toggled)
+        quick.addWidget(self._sort_dir_btn)
         layout.addLayout(quick)
 
         # グリッドビュー
@@ -290,22 +313,46 @@ class ImagePickerDialog(QDialog):
         self._address_bar.setStyleSheet("")
         self._btn_up.setEnabled(directory.parent != directory)
 
-        items: list[_PickerItem] = []
         try:
-            entries = sorted(
-                directory.iterdir(),
-                key=lambda p: (not p.is_dir(), p.name.lower()),
-            )
+            all_entries = [p for p in directory.iterdir() if not p.name.startswith(".")]
         except PermissionError:
-            entries = []
+            all_entries = []
 
-        for entry in entries:
-            if entry.name.startswith("."):
-                continue
-            if entry.is_dir():
-                items.append(_PickerItem(str(entry), entry.name, is_folder=True))
-            elif self._mode == "image" and entry.suffix.lower() in IMAGE_EXTENSIONS:
-                items.append(_PickerItem(str(entry), entry.name, is_folder=False))
+        def _sort_key(p: Path):
+            if self._sort_key == "mtime":
+                try:
+                    return p.stat().st_mtime
+                except OSError:
+                    return 0.0
+            elif self._sort_key == "size":
+                try:
+                    return p.stat().st_size if p.is_file() else 0
+                except OSError:
+                    return 0
+            return p.name.lower()
+
+        rev = not self._sort_ascending
+        folders = sorted([p for p in all_entries if p.is_dir()], key=_sort_key, reverse=rev)
+        files = sorted([p for p in all_entries if not p.is_dir()], key=_sort_key, reverse=rev)
+
+        items: list[_PickerItem] = []
+        for entry in folders:
+            try:
+                st = entry.stat()
+                mtime, size = st.st_mtime, 0
+            except OSError:
+                mtime, size = 0.0, 0
+            items.append(_PickerItem(str(entry), entry.name, is_folder=True, mtime=mtime, size=size))
+        if self._mode == "image":
+            for entry in files:
+                if entry.suffix.lower() not in IMAGE_EXTENSIONS:
+                    continue
+                try:
+                    st = entry.stat()
+                    mtime, size = st.st_mtime, st.st_size
+                except OSError:
+                    mtime, size = 0.0, 0
+                items.append(_PickerItem(str(entry), entry.name, is_folder=False, mtime=mtime, size=size))
 
         self._model.set_items(items)
         self._view.clearSelection()
@@ -322,6 +369,15 @@ class ImagePickerDialog(QDialog):
 
     def _on_go_up(self) -> None:
         self._navigate(self._current_dir.parent)
+
+    def _on_sort_changed(self, index: int) -> None:
+        self._sort_key = self._sort_combo.itemData(index)
+        self._navigate(self._current_dir)
+
+    def _on_sort_dir_toggled(self, checked: bool) -> None:
+        self._sort_ascending = checked
+        self._sort_dir_btn.setText("↑" if checked else "↓")
+        self._navigate(self._current_dir)
 
     def _on_address_validate(self) -> None:
         """デバウンス後にバリデートのみ実施（ナビゲートしない）。"""

--- a/app/widgets/image_picker.py
+++ b/app/widgets/image_picker.py
@@ -193,6 +193,7 @@ class ImagePickerDialog(QDialog):
         self._address_valid = True
         self._sort_key: str = "name"
         self._sort_ascending: bool = True
+        self._show_hidden: bool = False
         self.setWindowTitle("フォルダを選択" if mode == "folder" else "サムネイル画像を選択")
         self.setMinimumSize(640, 520)
         self._selected_path: str | None = None
@@ -238,6 +239,11 @@ class ImagePickerDialog(QDialog):
                 btn.hide()
             quick.addWidget(btn)
         quick.addStretch()
+        self._hidden_btn = QPushButton("隠しファイル")
+        self._hidden_btn.setCheckable(True)
+        self._hidden_btn.setChecked(False)
+        self._hidden_btn.toggled.connect(self._on_toggle_hidden)
+        quick.addWidget(self._hidden_btn)
         self._sort_combo = QComboBox()
         for label, key in _SORT_OPTIONS:
             self._sort_combo.addItem(label, userData=key)
@@ -314,7 +320,10 @@ class ImagePickerDialog(QDialog):
         self._btn_up.setEnabled(directory.parent != directory)
 
         try:
-            all_entries = [p for p in directory.iterdir() if not p.name.startswith(".")]
+            all_entries = [
+                p for p in directory.iterdir()
+                if self._show_hidden or not p.name.startswith(".")
+            ]
         except PermissionError:
             all_entries = []
 
@@ -377,6 +386,10 @@ class ImagePickerDialog(QDialog):
     def _on_sort_dir_toggled(self, checked: bool) -> None:
         self._sort_ascending = checked
         self._sort_dir_btn.setText("↑" if checked else "↓")
+        self._navigate(self._current_dir)
+
+    def _on_toggle_hidden(self, checked: bool) -> None:
+        self._show_hidden = checked
         self._navigate(self._current_dir)
 
     def _on_address_validate(self) -> None:

--- a/app/widgets/image_picker.py
+++ b/app/widgets/image_picker.py
@@ -58,6 +58,10 @@ _ITEM_W = _THUMB_PX + 8
 _ITEM_H = 4 + _THUMB_PX + 4 + _LABEL_H + 4
 _GRID_SIZE = QSize(_ITEM_W + 8, _ITEM_H + 8)
 
+# リスト表示サイズ
+_LIST_ROW_H = 28
+_LIST_THUMB_PX = 20
+
 
 @dataclass
 class _PickerItem:
@@ -100,8 +104,14 @@ class _PickerDelegate(QStyledItemDelegate):
         self._view = view
         self._loader = shared_loader(_LOADER_SIZE)
         self._pixmaps: dict[str, QPixmap | None] = {}
+        self._is_list_mode: bool = False
+
+    def set_list_mode(self, enabled: bool) -> None:
+        self._is_list_mode = enabled
 
     def sizeHint(self, option, index) -> QSize:
+        if self._is_list_mode:
+            return QSize(200, _LIST_ROW_H)
         return QSize(_ITEM_W, _ITEM_H)
 
     def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
@@ -113,10 +123,15 @@ class _PickerDelegate(QStyledItemDelegate):
         is_selected = bool(option.state & QStyle.StateFlag.State_Selected)
         palette = option.palette
 
-        # 背景
         bg = palette.highlight().color() if is_selected else palette.base().color()
         painter.fillRect(rect, bg)
 
+        if self._is_list_mode:
+            self._paint_list(painter, rect, item, is_selected, palette)
+        else:
+            self._paint_icon(painter, rect, item, is_selected, palette)
+
+    def _paint_icon(self, painter, rect, item, is_selected, palette) -> None:
         # サムネイル領域（ラベル分を下から除く）
         thumb_rect = rect.adjusted(4, 4, -4, -(4 + _LABEL_H + 4))
 
@@ -136,18 +151,15 @@ class _PickerDelegate(QStyledItemDelegate):
 
             pixmap = self._pixmaps.get(item.path)
             if pixmap:
+                painter.fillRect(thumb_rect, QColor(0, 0, 0))
                 scaled = pixmap.scaled(
                     thumb_rect.size(),
-                    Qt.AspectRatioMode.KeepAspectRatioByExpanding,
+                    Qt.AspectRatioMode.KeepAspectRatio,
                     Qt.TransformationMode.SmoothTransformation,
                 )
-                x_off = (scaled.width() - thumb_rect.width()) // 2
-                y_off = (scaled.height() - thumb_rect.height()) // 2
-                painter.drawPixmap(
-                    thumb_rect,
-                    scaled,
-                    scaled.rect().adjusted(x_off, y_off, -x_off, -y_off),
-                )
+                x_off = (thumb_rect.width() - scaled.width()) // 2
+                y_off = (thumb_rect.height() - scaled.height()) // 2
+                painter.drawPixmap(thumb_rect.x() + x_off, thumb_rect.y() + y_off, scaled)
             else:
                 painter.fillRect(thumb_rect, palette.mid().color())
                 painter.setPen(palette.placeholderText().color())
@@ -173,6 +185,39 @@ class _PickerDelegate(QStyledItemDelegate):
             label_rect, Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter, elided
         )
 
+    def _paint_list(self, painter, rect, item, is_selected, palette) -> None:
+        pad = (rect.height() - _LIST_THUMB_PX) // 2
+        thumb_rect = rect.adjusted(4, pad, 4 + _LIST_THUMB_PX - rect.width(), -pad)
+
+        if item.is_folder:
+            painter.setPen(palette.text().color())
+            painter.drawText(thumb_rect, Qt.AlignmentFlag.AlignCenter, "📁")
+        else:
+            if item.path not in self._pixmaps:
+                self._pixmaps[item.path] = None
+                self._loader.request(item.path, self._on_thumbnail_ready)
+
+            pixmap = self._pixmaps.get(item.path)
+            if pixmap:
+                painter.fillRect(thumb_rect, QColor(0, 0, 0))
+                scaled = pixmap.scaled(
+                    thumb_rect.size(),
+                    Qt.AspectRatioMode.KeepAspectRatio,
+                    Qt.TransformationMode.SmoothTransformation,
+                )
+                x_off = (thumb_rect.width() - scaled.width()) // 2
+                y_off = (thumb_rect.height() - scaled.height()) // 2
+                painter.drawPixmap(thumb_rect.x() + x_off, thumb_rect.y() + y_off, scaled)
+            else:
+                painter.setPen(palette.placeholderText().color())
+                painter.drawText(thumb_rect, Qt.AlignmentFlag.AlignCenter, "🖼")
+
+        painter.setPen(palette.highlightedText().color() if is_selected else palette.text().color())
+        text_rect = rect.adjusted(4 + _LIST_THUMB_PX + 4, 0, -4, 0)
+        fm = painter.fontMetrics()
+        elided = fm.elidedText(item.name, Qt.TextElideMode.ElideRight, text_rect.width())
+        painter.drawText(text_rect, Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft, elided)
+
     def _on_thumbnail_ready(self, path: str, pixmap: QPixmap | None) -> None:
         self._pixmaps[path] = pixmap
         self._view.viewport().update()
@@ -194,6 +239,7 @@ class ImagePickerDialog(QDialog):
         self._sort_key: str = "name"
         self._sort_ascending: bool = True
         self._show_hidden: bool = False
+        self._icon_mode: bool = True
         self.setWindowTitle("フォルダを選択" if mode == "folder" else "サムネイル画像を選択")
         self.setMinimumSize(640, 520)
         self._selected_path: str | None = None
@@ -255,6 +301,11 @@ class ImagePickerDialog(QDialog):
         self._sort_dir_btn.setFixedWidth(32)
         self._sort_dir_btn.toggled.connect(self._on_sort_dir_toggled)
         quick.addWidget(self._sort_dir_btn)
+        self._view_btn = QPushButton("リスト")
+        self._view_btn.setCheckable(True)
+        self._view_btn.setChecked(False)
+        self._view_btn.toggled.connect(self._on_view_toggled)
+        quick.addWidget(self._view_btn)
         layout.addLayout(quick)
 
         # グリッドビュー
@@ -391,6 +442,22 @@ class ImagePickerDialog(QDialog):
     def _on_toggle_hidden(self, checked: bool) -> None:
         self._show_hidden = checked
         self._navigate(self._current_dir)
+
+    def _on_view_toggled(self, checked: bool) -> None:
+        self._set_view_mode(not checked)
+
+    def _set_view_mode(self, icon_mode: bool) -> None:
+        self._icon_mode = icon_mode
+        self._delegate.set_list_mode(not icon_mode)
+        if icon_mode:
+            self._view.setViewMode(QListView.ViewMode.IconMode)
+            self._view.setGridSize(_GRID_SIZE)
+            self._view.setSpacing(4)
+        else:
+            self._view.setViewMode(QListView.ViewMode.ListMode)
+            self._view.setGridSize(QSize())
+            self._view.setSpacing(0)
+        self._view.viewport().update()
 
     def _on_address_validate(self) -> None:
         """デバウンス後にバリデートのみ実施（ナビゲートしない）。"""


### PR DESCRIPTION
## Summary

- **#20** `ImagePickerDialog` にソート機能を追加
  - ソートキー選択: 名前 / 更新日時 / サイズ（`QComboBox`）
  - 昇降順トグルボタン（↑ / ↓）
  - フォルダは常に先頭を維持しつつ、フォルダ・ファイルを個別にソート
  - `_SORT_OPTIONS`（表示ラベル, 内部キー）で表示文字列とロジックを分離し i18n に対応
  - ソート設定はダイアログのライフタイム中保持（永続化なし）
  - `_PickerItem` に `mtime: float`・`size: int` フィールドを追加
- **#21** `ImagePickerDialog` に隠しファイル表示切替を追加
  - 「隠しファイル」チェッカブルボタン（クイックアクセス行、ソートコンボの左）
  - OFF（デフォルト）: `.` 始まりのエントリを除外
  - ON: 隠しファイル・フォルダも表示
  - トグル状態はダイアログのライフタイム中保持
- **#22** `ImagePickerDialog` にビュー切替を追加
  - 「リスト」チェッカブルボタン（クイックアクセス行の右端）でアイコングリッド / リスト表示をトグル
  - アイコングリッド（デフォルト）: サムネイル付き正方形タイル
  - リスト表示: 20px サムネイル + ファイル名の1行レイアウト
  - `_PickerDelegate` を単一クラスで両モード対応（`_paint_icon` / `_paint_list` に分割）、`_pixmaps` キャッシュを共有
  - ビュー設定はダイアログのライフタイム中保持
- **サムネイル描画変更**（`ImagePickerDialog` + `CardGrid`）
  - `KeepAspectRatioByExpanding`（センタークロップ）→ `KeepAspectRatio`（レターボックス）に変更
  - 画像全体を常に表示、余白を黒（`QColor(0, 0, 0)`）で塗りつぶす

Closes #20
Closes #21
Closes #22

## Test plan

- [ ] クイックアクセス行の右端にソートコンボボックスと ↑/↓ ボタンが表示される
- [ ] 「名前」でアルファベット順にソートされる
- [ ] 「更新日時」で更新日時順にソートされる
- [ ] 「サイズ」でファイルサイズ順にソートされる
- [ ] ↑/↓ ボタンで昇順・降順が切り替わる
- [ ] どのソート設定でもフォルダが先頭に表示される
- [ ] 別ディレクトリに移動してもソート設定が維持される
- [ ] フォルダモード（`mode="folder"`）でも正常動作する
- [ ] 「隠しファイル」ボタン OFF: `.` 始まりのエントリが非表示
- [ ] 「隠しファイル」ボタン ON: `.` 始まりのエントリが表示される
- [ ] 別ディレクトリに移動してもトグル状態が維持される
- [ ] 「リスト」ボタンでリスト表示に切り替わる（小サムネイル + ファイル名）
- [ ] 再クリックでアイコングリッドに戻る
- [ ] リストモードでフォルダをダブルクリックするとナビゲートできる
- [ ] リストモードでソート・隠しファイルトグルが正常動作する
- [ ] 縦長画像が CardGrid のサムネイルで全体表示される（黒レターボックス）
- [ ] 縦長画像が ImagePickerDialog のサムネイルで全体表示される（黒レターボックス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)