### PR TITLE
feat: #5 #7 エラー表示（フォルダ不存在・起動時エラー）

### DIFF
--- a/app/models/app_config.py
+++ b/app/models/app_config.py
@@ -16,6 +16,12 @@ APP_NAME = "image-folder-viewer"
 ORG_NAME = "org.example"
 MAX_RECENT_PROFILES = 10
 
+_config_load_warning: str | None = None
+
+
+def get_config_load_warning() -> str | None:
+    return _config_load_warning
+
 
 def _config_path() -> Path:
     data_dir = QStandardPaths.writableLocation(
@@ -85,13 +91,16 @@ class AppConfig:
 
 
 def load_app_config() -> AppConfig:
+    global _config_load_warning
+    _config_load_warning = None
     path = _config_path()
     if not path.exists():
         return AppConfig()
     try:
         with open(path, encoding="utf-8") as f:
             return AppConfig.from_dict(json.load(f))
-    except Exception:
+    except Exception as e:
+        _config_load_warning = f"設定ファイルの読み込みに失敗しました（デフォルト設定で起動）:\n{e}"
         return AppConfig()
 
 

--- a/app/widgets/card_grid.py
+++ b/app/widgets/card_grid.py
@@ -17,7 +17,7 @@ from PyQt6.QtCore import (
     Qt,
     pyqtSignal,
 )
-from PyQt6.QtGui import QColor, QPainter, QPixmap
+from PyQt6.QtGui import QColor, QPainter, QPen, QPixmap
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QListView,
@@ -212,27 +212,40 @@ class CardDelegate(QStyledItemDelegate):
         # サムネイル領域
         thumb_rect = rect.adjusted(4, 4, -4, -(CARD_HEIGHT - THUMB_H - 4))
 
-        if card.thumbnail and card.thumbnail not in self._pixmaps:
-            # 初回リクエスト
-            self._pixmaps[card.thumbnail] = None  # ロード中マーカー
-            self._loader.request(card.thumbnail, self._on_thumbnail_ready)
+        folder_exists = Path(card.folder_path).exists() if card.folder_path else False
 
-        pixmap = self._pixmaps.get(card.thumbnail) if card.thumbnail else None
-        if pixmap:
-            painter.fillRect(thumb_rect, QColor(0, 0, 0))
-            scaled = pixmap.scaled(
-                thumb_rect.size(),
-                Qt.AspectRatioMode.KeepAspectRatio,
-                Qt.TransformationMode.SmoothTransformation,
-            )
-            x_off = (thumb_rect.width() - scaled.width()) // 2
-            y_off = (thumb_rect.height() - scaled.height()) // 2
-            painter.drawPixmap(thumb_rect.x() + x_off, thumb_rect.y() + y_off, scaled)
+        if not folder_exists:
+            # フォルダ不存在: エラー表示
+            painter.fillRect(thumb_rect, QColor("#3a1010"))
+            old_font = painter.font()
+            err_font = painter.font()
+            err_font.setPointSize(24)
+            painter.setFont(err_font)
+            painter.setPen(QColor("#ff6666"))
+            painter.drawText(thumb_rect, Qt.AlignmentFlag.AlignCenter, "⚠")
+            painter.setFont(old_font)
         else:
-            # サムネイルなし
-            painter.fillRect(thumb_rect, QColor(colors["thumb_bg"]))
-            painter.setPen(QColor(colors["icon_fg"]))
-            painter.drawText(thumb_rect, Qt.AlignmentFlag.AlignCenter, "📁")
+            if card.thumbnail and card.thumbnail not in self._pixmaps:
+                # 初回リクエスト
+                self._pixmaps[card.thumbnail] = None  # ロード中マーカー
+                self._loader.request(card.thumbnail, self._on_thumbnail_ready)
+
+            pixmap = self._pixmaps.get(card.thumbnail) if card.thumbnail else None
+            if pixmap:
+                painter.fillRect(thumb_rect, QColor(0, 0, 0))
+                scaled = pixmap.scaled(
+                    thumb_rect.size(),
+                    Qt.AspectRatioMode.KeepAspectRatio,
+                    Qt.TransformationMode.SmoothTransformation,
+                )
+                x_off = (thumb_rect.width() - scaled.width()) // 2
+                y_off = (thumb_rect.height() - scaled.height()) // 2
+                painter.drawPixmap(thumb_rect.x() + x_off, thumb_rect.y() + y_off, scaled)
+            else:
+                # サムネイルなし
+                painter.fillRect(thumb_rect, QColor(colors["thumb_bg"]))
+                painter.setPen(QColor(colors["icon_fg"]))
+                painter.drawText(thumb_rect, Qt.AlignmentFlag.AlignCenter, "📁")
 
         # タイトル
         title_rect = rect.adjusted(4, THUMB_H + 8, -4, -4)
@@ -242,6 +255,14 @@ class CardDelegate(QStyledItemDelegate):
             Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop,
             card.title,
         )
+
+        # フォルダ不存在: カード全体に赤枠
+        if not folder_exists:
+            pen = QPen(QColor("#ff4444"))
+            pen.setWidth(2)
+            painter.setPen(pen)
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawRect(rect.adjusted(1, 1, -1, -1))
 
     def _on_thumbnail_ready(self, path: str, pixmap: QPixmap | None) -> None:
         self._pixmaps[path] = pixmap
@@ -332,8 +353,13 @@ class CardGrid(QWidget):
     def open_selected(self) -> None:
         """現在選択中のカードを開く（Enter キー用）。"""
         card = self.current_card()
-        if card and Path(card.folder_path).exists():
-            self.card_opened.emit(card)
+        if not card:
+            return
+        if not Path(card.folder_path).exists():
+            QMessageBox.warning(self, "エラー",
+                f"フォルダが見つかりません:\n{card.folder_path}")
+            return
+        self.card_opened.emit(card)
 
     def set_profile(self, profile: ProfileData) -> None:
         """プロファイルを切り替えてグリッドを更新する。"""
@@ -354,8 +380,13 @@ class CardGrid(QWidget):
 
     def _on_open_card(self, index: QModelIndex) -> None:
         card: Card = index.data(Qt.ItemDataRole.UserRole)
-        if card and Path(card.folder_path).exists():
-            self.card_opened.emit(card)
+        if not card:
+            return
+        if not Path(card.folder_path).exists():
+            QMessageBox.warning(self, "エラー",
+                f"フォルダが見つかりません:\n{card.folder_path}")
+            return
+        self.card_opened.emit(card)
 
     def _on_context_menu(self, pos) -> None:
         index = self._view.indexAt(pos)

--- a/app/windows/main_window.py
+++ b/app/windows/main_window.py
@@ -391,6 +391,13 @@ class MainWindow(QMainWindow):
     def showEvent(self, event) -> None:
         super().showEvent(event)
         QTimer.singleShot(0, self._restore_card_focus)
+        QTimer.singleShot(0, self._show_config_warning)
+
+    def _show_config_warning(self) -> None:
+        from app.models.app_config import get_config_load_warning
+        warn = get_config_load_warning()
+        if warn:
+            self._toast.add_toast(warn, ToastType.ERROR)
 
     def closeEvent(self, event) -> None:
         self._save_window_state()

--- a/app/windows/startup_window.py
+++ b/app/windows/startup_window.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
     QDialog,
     QFileDialog,
@@ -42,6 +42,7 @@ class StartupWindow(QDialog):
         self._profile: ProfileData | None = None
         self._profile_path: str | None = None
         self._launched: bool = False  # 自動オープン成功フラグ
+        self._auto_open_error: str | None = None
 
         self._build_ui()
         self._refresh_recent_list()
@@ -125,8 +126,8 @@ class StartupWindow(QDialog):
     def _auto_open(self, path: str) -> None:
         try:
             self._open_profile(path)
-        except Exception:
-            pass  # 失敗時はそのまま StartupWindow を表示
+        except Exception as e:
+            self._auto_open_error = f"プロファイルの自動オープンに失敗しました:\n{e}"
 
     def _open_profile(self, path: str) -> None:
         profile = load_profile(path)
@@ -235,3 +236,20 @@ class StartupWindow(QDialog):
         except Exception:
             pass  # 将来エラー通知を追加予定
         self._refresh_recent_list()
+
+    # ------------------------------------------------------------------
+    # ウィンドウイベント
+    # ------------------------------------------------------------------
+
+    def showEvent(self, event) -> None:
+        super().showEvent(event)
+        QTimer.singleShot(0, self._show_startup_warnings)
+
+    def _show_startup_warnings(self) -> None:
+        from app.models.app_config import get_config_load_warning
+        warn = get_config_load_warning()
+        if warn:
+            QMessageBox.warning(self, "設定読み込みエラー", warn)
+        if self._auto_open_error:
+            QMessageBox.warning(self, "自動オープン失敗", self._auto_open_error)
+            self._auto_open_error = None

--- a/app/windows/viewer_window.py
+++ b/app/windows/viewer_window.py
@@ -214,9 +214,15 @@ class ViewerWindow(QMainWindow):
     # ------------------------------------------------------------------
 
     def _load_images(self) -> None:
+        if not Path(self._card.folder_path).exists():
+            QMessageBox.warning(self, "エラー",
+                f"フォルダが見つかりません:\n{self._card.folder_path}")
+            self._on_back()
+            return
         self._images = collect_images(self._card.folder_path, self._card.recursive)
         if not self._images:
-            QMessageBox.warning(self, "エラー", "フォルダに画像が見つかりません")
+            QMessageBox.warning(self, "エラー",
+                f"フォルダに画像が見つかりません:\n{self._card.folder_path}")
             self._on_back()
             return
 


### PR DESCRIPTION
## Summary

- **#5 CardGrid フォルダ不存在エラー表示**: `folder_path` が存在しないカードを暗赤背景 + ⚠ + 赤枠でエラー描画。クリックで開こうとした際に「フォルダが見つかりません」ダイアログを表示
- **#7 起動時エラー表示**:
  - `load_app_config()` が JSON 破損等で失敗した場合、警告文字列を `get_config_load_warning()` で取得できるよう記録
  - `StartupWindow` で自動オープン失敗時のエラーを `showEvent` 後に `QMessageBox.warning()` で表示
  - `MainWindow` 起動時に config 警告をトーストで表示（自動オープン成功時もカバー）
  - `ViewerWindow._load_images()` でフォルダ不存在を明示的にチェックし、パス付きエラーメッセージを表示

## Test plan

- [ ] 存在しないフォルダパスのカードを作成（`.ivprofile` を直接編集）→ 赤枠 + ⚠ が表示される
- [ ] 上記カードを開こうとする → 「フォルダが見つかりません」ダイアログが表示される
- [ ] `app_config.json` を不正な JSON に書き換えて起動 → デフォルト設定で起動し、警告が表示される
- [ ] `app_config.json` の `recentProfiles` に存在しないパスを書いて起動 → StartupWindow + 「自動オープン失敗」ダイアログが表示される
- [ ] ViewerWindow をフォルダ削除後に開く → 「フォルダが見つかりません」ダイアログ後 MainWindow に戻る

Closes #5
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)